### PR TITLE
test: テスト環境の基盤セットアップ #87

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,155 @@
+# Claude Project Rules
+
+## プロジェクト概要
+このプロジェクトは、本の管理と共有を行うWebアプリケーション「minelibrary」です。
+Laravel 11とReact（Inertia.js）を使用して構築されています。
+
+## 技術スタック
+- **バックエンド**: Laravel 11
+- **フロントエンド**: React with TypeScript, Inertia.js
+- **データベース**: SQLite
+- **スタイリング**: Tailwind CSS
+- **コンポーネント**: shadcn/ui
+
+## コーディング規約
+
+### Laravel (PHP)
+1. **命名規則**
+   - クラス名: PascalCase (例: `BookShelfController`)
+   - メソッド名: camelCase (例: `getBooks`)
+   - 変数名: camelCase (例: `$bookShelf`)
+   - データベーステーブル名: snake_case、複数形 (例: `book_shelves`)
+   - カラム名: snake_case (例: `book_shelf_name`)
+
+2. **N+1クエリ問題の防止**
+   - Eager Loadingを積極的に使用する (`with()`, `load()`)
+   - `withCount()`を使用してカウントクエリを最適化
+   - 複数のレコードに対する処理では、事前に必要なデータを一括取得
+
+3. **コントローラー**
+   - 1つのコントローラーは1つのリソースに対応
+   - RESTfulな設計を心がける
+   - ビジネスロジックはモデルやサービスクラスに移動
+
+### React/TypeScript
+1. **命名規則**
+   - コンポーネント: PascalCase (例: `BookShelfList`)
+   - 関数・変数: camelCase (例: `handleSubmit`)
+   - 型定義: PascalCase (例: `BookShelfType`)
+   - ファイル名: コンポーネントはPascalCase、それ以外はkebab-case
+
+2. **コンポーネント設計**
+   - 関数コンポーネントを使用
+   - TypeScriptの型定義を必ず行う
+   - PropsはinterfaceまたはtypeAliasで定義
+
+3. **ディレクトリ構造**
+   ```
+   resources/js/
+   ├── components/     # 共通コンポーネント
+   ├── features/       # 機能別のコンポーネント
+   ├── hooks/          # カスタムフック
+   ├── layouts/        # レイアウトコンポーネント
+   ├── pages/          # ページコンポーネント
+   └── types/          # 型定義
+   ```
+
+## 開発ワークフロー
+
+1. **ブランチ戦略**
+   - mainブランチが本番環境
+   - 機能開発: `feature/機能名#issue番号`
+   - バグ修正: `fix/問題の説明#issue番号`
+   - リファクタリング: `refactor/対象#issue番号`
+
+2. **コミットメッセージ**
+   - 日本語で記述
+   - プレフィックスを使用: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`
+   - 例: `feat: 本棚のお気に入り機能を追加`
+
+3. **プルリクエスト**
+   - タイトルにIssue番号を含める
+   - 変更内容を明確に記述
+   - テストが通ることを確認
+
+## テストとビルド
+
+### テストコマンド
+```bash
+# PHPUnit テスト（Pest）
+php artisan test
+
+# 特定のテストファイルを実行
+php artisan test tests/Feature/BookShelfControllerTest.php
+
+# カバレッジレポート付きテスト
+php artisan test --coverage
+
+# 並列実行（高速化）
+php artisan test --parallel
+
+# JavaScript リンティング
+npm run lint
+```
+
+### ビルドコマンド
+```bash
+# 開発環境
+npm run dev
+
+# 本番環境
+npm run build
+```
+
+### テストガイドライン
+1. **テスト作成のルール**
+   - 新機能追加時は必ずテストを作成
+   - バグ修正時は再発防止のためのテストを追加
+   - テストはAAA（Arrange-Act-Assert）パターンに従う
+
+2. **テストの種類**
+   - ユニットテスト: モデルやサービスクラスの個別メソッド
+   - フィーチャーテスト: APIエンドポイントや統合的な機能
+   - 詳細は`TESTING.md`を参照
+
+3. **カバレッジ目標**
+   - 初期目標: 60%以上
+   - 最終目標: 80%以上
+
+## パフォーマンス最適化
+
+1. **データベースクエリ**
+   - N+1問題を避ける
+   - 適切なインデックスを設定
+   - 不要なデータは取得しない（select()を使用）
+
+2. **フロントエンド**
+   - 画像の遅延読み込み
+   - コンポーネントの適切なメモ化
+   - 不要な再レンダリングを避ける
+
+## セキュリティ
+
+1. **認証・認可**
+   - すべてのルートに適切な認証を設定
+   - ユーザーの権限を確認してからデータアクセス
+   - CSRF保護を有効化
+
+2. **データ検証**
+   - フロントエンドとバックエンドの両方で検証
+   - SQLインジェクション対策（Eloquent ORMを使用）
+   - XSS対策（Bladeテンプレートのエスケープ機能を使用）
+
+## その他の注意事項
+
+1. **環境変数**
+   - 本番環境の設定は`.env`ファイルで管理
+   - シークレット情報はコミットしない
+
+2. **ログ**
+   - エラーは適切にログに記録
+   - デバッグ情報は開発環境のみ
+
+3. **コメント**
+   - 複雑なロジックには必ずコメントを追加
+   - ただし、コードが自己文書化されている場合は不要

--- a/README.md
+++ b/README.md
@@ -63,3 +63,33 @@ text
         },
     },
 →記載しないとインポートエラーになる
+
+## テストの実行
+
+### PHPテスト（Pest）
+プロジェクトではPestフレームワークを使用してテストを作成しています。
+
+```bash
+# 全てのテストを実行
+php artisan test
+
+# 特定のテストファイルを実行
+php artisan test tests/Feature/BookShelfControllerTest.php
+
+# カバレッジレポート付きで実行
+php artisan test --coverage
+
+# 並列実行（高速化）
+php artisan test --parallel
+```
+
+### テストデータベース
+テスト実行時は自動的にインメモリSQLiteデータベースを使用します。
+本番データベースには影響しません。
+
+### テストの書き方
+新しいテストを作成する場合は、`TESTING.md`を参照してください。
+
+詳細なテストガイドラインは以下を参照：
+- [TESTING.md](./TESTING.md) - テスト戦略とガイドライン
+- [CLAUDE.md](./CLAUDE.md) - プロジェクトルールとコーディング規約

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,217 @@
+# テストガイド
+
+## 概要
+このドキュメントは、minelibraryプロジェクトのテスト戦略とガイドラインを定義します。
+
+## テストピラミッド
+
+### 1. ユニットテスト（Unit Tests）
+- **目的**: 個々のメソッドやクラスの動作を検証
+- **対象**: モデル、ヘルパー関数、サービスクラス
+- **実行時間**: < 1秒/テスト
+- **カバレッジ目標**: 80%以上
+
+### 2. フィーチャーテスト（Feature Tests）
+- **目的**: APIエンドポイントや機能全体の動作を検証
+- **対象**: コントローラー、ミドルウェア、認証フロー
+- **実行時間**: < 5秒/テスト
+- **カバレッジ目標**: 70%以上
+
+### 3. 統合テスト（Integration Tests）
+- **目的**: 外部サービスとの連携を検証
+- **対象**: 楽天API連携、メール送信
+- **実行時間**: < 10秒/テスト
+- **カバレッジ目標**: 60%以上
+
+## テスト実行方法
+
+### 全テストの実行
+```bash
+php artisan test
+```
+
+### 特定のテストファイルの実行
+```bash
+php artisan test tests/Feature/BookShelfControllerTest.php
+```
+
+### カバレッジレポートの生成
+```bash
+php artisan test --coverage
+```
+
+### 並列実行（高速化）
+```bash
+php artisan test --parallel
+```
+
+## テストの書き方
+
+### 基本構造（Pest）
+```php
+<?php
+
+use App\Models\User;
+use App\Models\BookShelf;
+
+beforeEach(function () {
+    // 各テスト前の準備
+    $this->user = User::factory()->create();
+});
+
+test('ユーザーは本棚を作成できる', function () {
+    $this->actingAs($this->user)
+        ->post('/api/bookshelves', [
+            'book_shelf_name' => 'お気に入りの本',
+            'description' => '私のお気に入りの本のコレクション',
+        ])
+        ->assertStatus(201)
+        ->assertJson([
+            'book_shelf_name' => 'お気に入りの本',
+        ]);
+    
+    $this->assertDatabaseHas('book_shelves', [
+        'user_id' => $this->user->id,
+        'book_shelf_name' => 'お気に入りの本',
+    ]);
+});
+```
+
+### 命名規則
+- テストファイル: `{対象クラス}Test.php`
+- テストメソッド: 日本語で何をテストするか明確に記述
+- データプロバイダー: `provide{データの説明}`
+
+### アサーション
+```php
+// ステータスコード
+->assertStatus(200)
+->assertCreated()
+->assertNotFound()
+
+// JSONレスポンス
+->assertJson(['key' => 'value'])
+->assertJsonStructure(['id', 'name'])
+
+// データベース
+$this->assertDatabaseHas('table', ['column' => 'value'])
+$this->assertDatabaseMissing('table', ['column' => 'value'])
+
+// 認証
+$this->assertAuthenticated()
+$this->assertGuest()
+```
+
+## テストデータの準備
+
+### ファクトリーの使用
+```php
+// 単一のモデル作成
+$user = User::factory()->create();
+
+// 複数のモデル作成
+$books = Book::factory()->count(5)->create();
+
+// リレーション付きモデル
+$bookShelf = BookShelf::factory()
+    ->for($user)
+    ->hasBooks(3)
+    ->create();
+```
+
+### テスト用シーダー
+```php
+// 特定のテスト用データセット
+$this->seed(TestBookSeeder::class);
+```
+
+## ベストプラクティス
+
+### 1. AAA パターン
+```php
+test('本棚に本を追加できる', function () {
+    // Arrange（準備）
+    $bookShelf = BookShelf::factory()->create();
+    $book = Book::factory()->create();
+    
+    // Act（実行）
+    $response = $this->post("/api/bookshelves/{$bookShelf->id}/books", [
+        'isbn' => $book->isbn,
+    ]);
+    
+    // Assert（検証）
+    $response->assertStatus(200);
+    $this->assertTrue($bookShelf->books->contains($book));
+});
+```
+
+### 2. テストの独立性
+- 各テストは他のテストに依存しない
+- テスト順序に関係なく実行可能
+- グローバル状態を変更しない
+
+### 3. テストデータ
+- 意味のあるテストデータを使用
+- マジックナンバーを避ける
+- ファクトリーを活用
+
+### 4. モックとスタブ
+```php
+// 外部APIのモック
+Http::fake([
+    'api.example.com/*' => Http::response(['result' => 'success'], 200),
+]);
+
+// サービスのモック
+$this->mock(BookService::class, function ($mock) {
+    $mock->shouldReceive('search')
+        ->once()
+        ->andReturn(collect([]));
+});
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **テストが遅い**
+   - `RefreshDatabase`の代わりに`DatabaseTransactions`を使用
+   - 不要なファクトリーの作成を避ける
+   - 並列実行を有効化
+
+2. **テストが不安定**
+   - 時間依存のテストには`Carbon::setTestNow()`を使用
+   - ランダムな値には固定シードを使用
+   - 外部APIは必ずモック化
+
+3. **メモリ不足**
+   - 大量のデータ作成を避ける
+   - `tearDown`でリソースを解放
+   - メモリリークをチェック
+
+## CI/CD連携
+
+### GitHub Actions設定
+```yaml
+- name: Run Tests
+  run: |
+    php artisan test --parallel
+    php artisan test --coverage --min=60
+```
+
+## テストカバレッジ目標
+
+### 現在の目標（Phase 1）
+- 全体: 60%以上
+- コントローラー: 70%以上
+- モデル: 80%以上
+
+### 最終目標（Phase 2）
+- 全体: 80%以上
+- コントローラー: 85%以上
+- モデル: 90%以上
+
+## 参考リンク
+- [Pest公式ドキュメント](https://pestphp.com/)
+- [Laravel Testing](https://laravel.com/docs/testing)
+- [PHPUnit Assertions](https://docs.phpunit.de/en/10.5/assertions.html)

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Book;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Book>
+ */
+class BookFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Book::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'isbn' => $this->faker->unique()->isbn13(),
+            'title' => $this->faker->sentence(3),
+            'author' => $this->faker->name(),
+            'publisher_name' => $this->faker->company() . '出版',
+            'sales_date' => $this->faker->dateTimeBetween('-5 years', 'now')->format('Y-m-d'),
+            'item_price' => $this->faker->numberBetween(500, 5000),
+            'item_caption' => $this->faker->paragraph(3),
+            'image_url' => $this->faker->imageUrl(200, 300, 'books'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+
+    /**
+     * プログラミング関連の本を生成
+     *
+     * @return static
+     */
+    public function programming(): static
+    {
+        return $this->state(function (array $attributes) {
+            $languages = ['PHP', 'JavaScript', 'Python', 'Ruby', 'Go', 'Rust', 'TypeScript'];
+            $topics = ['入門', '実践', '設計', 'パターン', 'テスト', 'リファクタリング'];
+            
+            $language = $this->faker->randomElement($languages);
+            $topic = $this->faker->randomElement($topics);
+            
+            return [
+                'title' => "{$language} {$topic}",
+                'item_caption' => "{$language}の{$topic}について詳しく解説した技術書です。",
+            ];
+        });
+    }
+
+    /**
+     * 小説を生成
+     *
+     * @return static
+     */
+    public function novel(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'title' => $this->faker->realText(20) . 'の物語',
+                'publisher_name' => $this->faker->randomElement(['文藝春秋', '新潮社', '講談社', '集英社']),
+                'item_caption' => $this->faker->realText(200),
+            ];
+        });
+    }
+
+    /**
+     * ビジネス書を生成
+     *
+     * @return static
+     */
+    public function business(): static
+    {
+        return $this->state(function (array $attributes) {
+            $topics = ['マネジメント', 'リーダーシップ', 'マーケティング', '戦略', 'イノベーション'];
+            $topic = $this->faker->randomElement($topics);
+            
+            return [
+                'title' => "実践{$topic}の教科書",
+                'item_caption' => "{$topic}について、実例を交えながら解説したビジネス書です。",
+                'item_price' => $this->faker->numberBetween(1500, 3000),
+            ];
+        });
+    }
+
+    /**
+     * 特定のISBNを持つ本を生成
+     *
+     * @param string $isbn
+     * @return static
+     */
+    public function withIsbn(string $isbn): static
+    {
+        return $this->state(function (array $attributes) use ($isbn) {
+            return [
+                'isbn' => $isbn,
+            ];
+        });
+    }
+}

--- a/database/factories/BookShelfFactory.php
+++ b/database/factories/BookShelfFactory.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BookShelf;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\BookShelf>
+ */
+class BookShelfFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = BookShelf::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'book_shelf_name' => $this->faker->words(3, true) . 'の本棚',
+            'description' => $this->faker->realText(100),
+            'is_public' => $this->faker->boolean(80), // 80%の確率で公開
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+
+    /**
+     * 公開本棚を生成
+     *
+     * @return static
+     */
+    public function public(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'is_public' => true,
+            ];
+        });
+    }
+
+    /**
+     * 非公開本棚を生成
+     *
+     * @return static
+     */
+    public function private(): static
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'is_public' => false,
+            ];
+        });
+    }
+
+    /**
+     * 特定のテーマの本棚を生成
+     *
+     * @param string $theme
+     * @return static
+     */
+    public function withTheme(string $theme): static
+    {
+        return $this->state(function (array $attributes) use ($theme) {
+            return [
+                'book_shelf_name' => $theme . 'の本棚',
+                'description' => $theme . 'に関する本を集めた本棚です。',
+            ];
+        });
+    }
+
+    /**
+     * プログラミング本棚を生成
+     *
+     * @return static
+     */
+    public function programming(): static
+    {
+        return $this->state(function (array $attributes) {
+            $languages = ['PHP', 'JavaScript', 'Python', 'Ruby', 'Go'];
+            $language = $this->faker->randomElement($languages);
+            
+            return [
+                'book_shelf_name' => $language . '学習本棚',
+                'description' => $language . 'の学習に役立つ本を集めています。',
+            ];
+        });
+    }
+
+    /**
+     * 読書リスト本棚を生成
+     *
+     * @return static
+     */
+    public function readingList(): static
+    {
+        return $this->state(function (array $attributes) {
+            $year = date('Y');
+            $month = $this->faker->monthName();
+            
+            return [
+                'book_shelf_name' => "{$year}年{$month}の読書リスト",
+                'description' => "今月読みたい本・読んだ本のリストです。",
+            ];
+        });
+    }
+
+    /**
+     * 特定のユーザーに属する本棚を生成
+     *
+     * @param User $user
+     * @return static
+     */
+    public function forUser(User $user): static
+    {
+        return $this->state(function (array $attributes) use ($user) {
+            return [
+                'user_id' => $user->id,
+            ];
+        });
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
 
         Schema::create('users', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->string('email')->unique();
             $table->string('name');
             $table->string('profile_image')->nullable();

--- a/database/seeders/TestBookSeeder.php
+++ b/database/seeders/TestBookSeeder.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Book;
+use App\Models\BookShelf;
+use App\Models\User;
+use App\Models\FavoriteBook;
+use App\Models\FavoriteBookShelf;
+use Illuminate\Database\Seeder;
+
+class TestBookSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // テストユーザーの作成
+        $testUser = User::factory()->create([
+            'email' => 'test@example.com',
+            'name' => 'テストユーザー',
+        ]);
+
+        $otherUser = User::factory()->create([
+            'email' => 'other@example.com',
+            'name' => '他のユーザー',
+        ]);
+
+        // プログラミング本の作成
+        $programmingBooks = [
+            [
+                'isbn' => '9784798151090',
+                'title' => 'PHPフレームワーク Laravel入門',
+                'author' => '掌田津耶乃',
+                'publisher_name' => '秀和システム',
+                'item_price' => 3300,
+            ],
+            [
+                'isbn' => '9784295013990',
+                'title' => 'TypeScript実践プログラミング',
+                'author' => 'Steve Fenton',
+                'publisher_name' => 'インプレス',
+                'item_price' => 3520,
+            ],
+            [
+                'isbn' => '9784873119380',
+                'title' => 'リーダブルコード',
+                'author' => 'Dustin Boswell, Trevor Foucher',
+                'publisher_name' => 'オライリージャパン',
+                'item_price' => 2640,
+            ],
+        ];
+
+        foreach ($programmingBooks as $bookData) {
+            Book::factory()->create($bookData);
+        }
+
+        // ランダムな本を追加生成
+        Book::factory()->count(10)->programming()->create();
+        Book::factory()->count(5)->novel()->create();
+        Book::factory()->count(5)->business()->create();
+
+        // テストユーザーの本棚作成
+        $myShelf = BookShelf::factory()->forUser($testUser)->create([
+            'book_shelf_name' => '私のプログラミング本棚',
+            'description' => 'プログラミング学習に使っている本のコレクション',
+            'is_public' => true,
+        ]);
+
+        $privateShelf = BookShelf::factory()->forUser($testUser)->private()->create([
+            'book_shelf_name' => '非公開の読書リスト',
+            'description' => '個人的な読書記録',
+        ]);
+
+        // 他のユーザーの公開本棚
+        $otherPublicShelf = BookShelf::factory()->forUser($otherUser)->public()->create([
+            'book_shelf_name' => 'おすすめビジネス書',
+            'description' => '仕事に役立つビジネス書を紹介',
+        ]);
+
+        // 本棚に本を追加
+        $allBooks = Book::all();
+        
+        // プログラミング本棚に本を追加
+        $myShelf->books()->attach(
+            Book::whereIn('isbn', array_column($programmingBooks, 'isbn'))->pluck('isbn')
+        );
+
+        // 非公開本棚にランダムな本を追加
+        $privateShelf->books()->attach(
+            $allBooks->random(5)->pluck('isbn')
+        );
+
+        // 他のユーザーの本棚にビジネス書を追加
+        $otherPublicShelf->books()->attach(
+            Book::factory()->count(5)->business()->create()->pluck('isbn')
+        );
+
+        // お気に入り本の設定
+        FavoriteBook::create([
+            'user_id' => $testUser->id,
+            'isbn' => '9784873119380', // リーダブルコード
+            'read_status' => 'read',
+        ]);
+
+        FavoriteBook::create([
+            'user_id' => $testUser->id,
+            'isbn' => '9784798151090', // Laravel入門
+            'read_status' => 'reading',
+        ]);
+
+        // お気に入り本棚の設定
+        FavoriteBookShelf::create([
+            'user_id' => $testUser->id,
+            'book_shelf_id' => $otherPublicShelf->id,
+        ]);
+
+        $this->command->info('Test data seeded successfully!');
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/BookShelfControllerTest.php
+++ b/tests/Feature/BookShelfControllerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Models\User;
+use App\Models\BookShelf;
+use App\Models\Book;
+use Tests\Helpers\AuthTestHelper;
+use Tests\Helpers\DatabaseTestHelper;
+use Tests\Helpers\ApiTestHelper;
+
+uses(AuthTestHelper::class, DatabaseTestHelper::class, ApiTestHelper::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('認証されていないユーザーは本棚一覧にアクセスできない', function () {
+    $this->get('/bookshelves')
+        ->assertRedirect('/login');
+});
+
+test('認証済みユーザーは本棚一覧を表示できる', function () {
+    $this->actingAs($this->user)
+        ->get('/bookshelves')
+        ->assertStatus(200);
+});
+
+test('ユーザーは新しい本棚を作成できる', function () {
+    $bookShelfData = [
+        'book_shelf_name' => 'テスト本棚',
+        'description' => 'これはテスト用の本棚です',
+    ];
+
+    $this->actingAs($this->user)
+        ->post('/api/bookshelves', $bookShelfData)
+        ->assertStatus(201)
+        ->assertJson([
+            'book_shelf_name' => 'テスト本棚',
+            'description' => 'これはテスト用の本棚です',
+            'is_public' => true,
+        ]);
+
+    $this->assertDatabaseHas('book_shelves', [
+        'user_id' => $this->user->id,
+        'book_shelf_name' => 'テスト本棚',
+    ]);
+});
+
+test('本棚作成時にバリデーションが機能する', function () {
+    $this->actingAs($this->user)
+        ->post('/api/bookshelves', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['book_shelf_name', 'description']);
+});
+
+test('ユーザーは自分の本棚を更新できる', function () {
+    $bookShelf = BookShelf::factory()->forUser($this->user)->create();
+
+    $updateData = [
+        'book_shelf_name' => '更新された本棚名',
+        'description' => '更新された説明',
+        'is_public' => false,
+    ];
+
+    $this->actingAs($this->user)
+        ->put("/api/bookshelves/{$bookShelf->id}", $updateData)
+        ->assertStatus(200);
+
+    $this->assertDatabaseHas('book_shelves', [
+        'id' => $bookShelf->id,
+        'book_shelf_name' => '更新された本棚名',
+        'description' => '更新された説明',
+        'is_public' => false,
+    ]);
+});
+
+test('ユーザーは他人の本棚を更新できない', function () {
+    $otherUser = User::factory()->create();
+    $bookShelf = BookShelf::factory()->forUser($otherUser)->create();
+
+    $this->actingAs($this->user)
+        ->put("/api/bookshelves/{$bookShelf->id}", [
+            'book_shelf_name' => '不正な更新',
+            'description' => '不正な説明',
+            'is_public' => false,
+        ])
+        ->assertStatus(404);
+});
+
+test('ユーザーは自分の本棚を削除できる', function () {
+    $bookShelf = BookShelf::factory()->forUser($this->user)->create();
+
+    $this->actingAs($this->user)
+        ->delete("/api/bookshelves/{$bookShelf->id}")
+        ->assertStatus(200);
+
+    $this->assertDatabaseMissing('book_shelves', [
+        'id' => $bookShelf->id,
+    ]);
+});
+
+test('本棚に本を追加できる', function () {
+    $bookShelf = BookShelf::factory()->forUser($this->user)->create();
+    $books = Book::factory()->count(3)->create();
+
+    $this->actingAs($this->user)
+        ->post('/api/bookshelves/books', [
+            'book_shelf_id' => $bookShelf->id,
+            'isbns' => $books->pluck('isbn')->toArray(),
+        ])
+        ->assertStatus(200);
+
+    foreach ($books as $book) {
+        $this->assertDatabaseHas('book_shelf_book', [
+            'book_shelf_id' => $bookShelf->id,
+            'isbn' => $book->isbn,
+        ]);
+    }
+});
+
+test('本棚から本を削除できる', function () {
+    $bookShelf = BookShelf::factory()->forUser($this->user)->create();
+    $book = Book::factory()->create();
+    $bookShelf->addBook($book->isbn);
+
+    $this->actingAs($this->user)
+        ->post('/api/bookshelves/books/remove', [
+            'book_shelf_id' => $bookShelf->id,
+            'isbn' => $book->isbn,
+        ])
+        ->assertStatus(200);
+
+    $this->assertDatabaseMissing('book_shelf_book', [
+        'book_shelf_id' => $bookShelf->id,
+        'isbn' => $book->isbn,
+    ]);
+});
+
+test('公開本棚一覧を表示できる', function () {
+    $otherUser = User::factory()->create();
+    BookShelf::factory()->count(3)->forUser($otherUser)->public()->create();
+    BookShelf::factory()->count(2)->forUser($otherUser)->private()->create();
+
+    $this->actingAs($this->user)
+        ->get("/users/{$otherUser->id}/bookshelves")
+        ->assertStatus(200)
+        ->assertInertia(fn ($page) => $page
+            ->component('features/bookshelf/pages/UserBookShelfList')
+            ->has('bookshelves', 3)
+        );
+});
+
+test('非公開本棚は他のユーザーに表示されない', function () {
+    $otherUser = User::factory()->create();
+    $privateBookShelf = BookShelf::factory()->forUser($otherUser)->private()->create();
+
+    $this->actingAs($this->user)
+        ->get("/users/{$otherUser->id}/bookshelves/{$privateBookShelf->id}")
+        ->assertStatus(404);
+});

--- a/tests/Helpers/ApiTestHelper.php
+++ b/tests/Helpers/ApiTestHelper.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Helpers;
+
+use Illuminate\Testing\TestResponse;
+
+trait ApiTestHelper
+{
+    /**
+     * APIレスポンスの基本構造を検証
+     *
+     * @param TestResponse $response
+     * @param int $expectedStatus
+     * @param array $expectedStructure
+     * @return TestResponse
+     */
+    protected function assertApiResponse(TestResponse $response, int $expectedStatus, array $expectedStructure = []): TestResponse
+    {
+        $response->assertStatus($expectedStatus);
+        
+        if (!empty($expectedStructure)) {
+            $response->assertJsonStructure($expectedStructure);
+        }
+        
+        return $response;
+    }
+
+    /**
+     * ページネーションAPIレスポンスの検証
+     *
+     * @param TestResponse $response
+     * @param string $dataKey
+     * @return TestResponse
+     */
+    protected function assertPaginatedResponse(TestResponse $response, string $dataKey = 'data'): TestResponse
+    {
+        return $response
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                $dataKey,
+                'links' => [
+                    'first',
+                    'last',
+                    'prev',
+                    'next',
+                ],
+                'meta' => [
+                    'current_page',
+                    'from',
+                    'last_page',
+                    'path',
+                    'per_page',
+                    'to',
+                    'total',
+                ],
+            ]);
+    }
+
+    /**
+     * バリデーションエラーレスポンスの検証
+     *
+     * @param TestResponse $response
+     * @param array $expectedErrors
+     * @return TestResponse
+     */
+    protected function assertValidationError(TestResponse $response, array $expectedErrors): TestResponse
+    {
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors($expectedErrors);
+        
+        return $response;
+    }
+
+    /**
+     * 成功レスポンスの検証
+     *
+     * @param TestResponse $response
+     * @param array $expectedData
+     * @param int $status
+     * @return TestResponse
+     */
+    protected function assertSuccessResponse(TestResponse $response, array $expectedData = [], int $status = 200): TestResponse
+    {
+        $response->assertStatus($status);
+        
+        if (!empty($expectedData)) {
+            $response->assertJson($expectedData);
+        }
+        
+        return $response;
+    }
+
+    /**
+     * エラーレスポンスの検証
+     *
+     * @param TestResponse $response
+     * @param string $expectedMessage
+     * @param int $status
+     * @return TestResponse
+     */
+    protected function assertErrorResponse(TestResponse $response, string $expectedMessage, int $status = 400): TestResponse
+    {
+        return $response
+            ->assertStatus($status)
+            ->assertJson([
+                'message' => $expectedMessage,
+            ]);
+    }
+
+    /**
+     * リソース作成レスポンスの検証
+     *
+     * @param TestResponse $response
+     * @param array $expectedData
+     * @return TestResponse
+     */
+    protected function assertCreatedResponse(TestResponse $response, array $expectedData = []): TestResponse
+    {
+        return $this->assertSuccessResponse($response, $expectedData, 201);
+    }
+
+    /**
+     * リソース削除レスポンスの検証
+     *
+     * @param TestResponse $response
+     * @return TestResponse
+     */
+    protected function assertDeletedResponse(TestResponse $response): TestResponse
+    {
+        return $response->assertStatus(204);
+    }
+
+    /**
+     * APIヘッダーを設定
+     *
+     * @param array $headers
+     * @return array
+     */
+    protected function apiHeaders(array $headers = []): array
+    {
+        return array_merge([
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ], $headers);
+    }
+
+    /**
+     * APIリクエストを実行
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array $data
+     * @param array $headers
+     * @return TestResponse
+     */
+    protected function apiRequest(string $method, string $uri, array $data = [], array $headers = []): TestResponse
+    {
+        return $this->withHeaders($this->apiHeaders($headers))
+            ->json($method, $uri, $data);
+    }
+}

--- a/tests/Helpers/AuthTestHelper.php
+++ b/tests/Helpers/AuthTestHelper.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Helpers;
+
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+trait AuthTestHelper
+{
+    /**
+     * 認証済みユーザーを作成し、そのユーザーとして行動する
+     *
+     * @param array $attributes
+     * @return User
+     */
+    protected function actingAsUser(array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        $this->actingAs($user);
+        return $user;
+    }
+
+    /**
+     * 認証が必要なエンドポイントのテスト
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array $data
+     * @return TestResponse
+     */
+    protected function assertAuthRequired(string $method, string $uri, array $data = []): TestResponse
+    {
+        $response = $this->json($method, $uri, $data);
+        $response->assertStatus(401);
+        return $response;
+    }
+
+    /**
+     * 認証済みユーザーでリクエストを実行
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array $data
+     * @param User|null $user
+     * @return TestResponse
+     */
+    protected function authenticatedRequest(string $method, string $uri, array $data = [], ?User $user = null): TestResponse
+    {
+        if (!$user) {
+            $user = User::factory()->create();
+        }
+        
+        return $this->actingAs($user)->json($method, $uri, $data);
+    }
+
+    /**
+     * 指定したユーザーがリソースにアクセスできないことを確認
+     *
+     * @param User $user
+     * @param string $method
+     * @param string $uri
+     * @param int $expectedStatus
+     * @return TestResponse
+     */
+    protected function assertUnauthorized(User $user, string $method, string $uri, int $expectedStatus = 403): TestResponse
+    {
+        $response = $this->actingAs($user)->json($method, $uri);
+        $response->assertStatus($expectedStatus);
+        return $response;
+    }
+
+    /**
+     * ログインエンドポイントをテスト
+     *
+     * @param string $email
+     * @param string $password
+     * @return TestResponse
+     */
+    protected function attemptLogin(string $email, string $password): TestResponse
+    {
+        return $this->post('/login', [
+            'email' => $email,
+            'password' => $password,
+        ]);
+    }
+
+    /**
+     * ユーザーを作成してログイン
+     *
+     * @param array $attributes
+     * @return User
+     */
+    protected function createAndLogin(array $attributes = []): User
+    {
+        $user = User::factory()->create(array_merge([
+            'password' => bcrypt('password'),
+        ], $attributes));
+        
+        $this->attemptLogin($user->email, 'password');
+        
+        return $user;
+    }
+}

--- a/tests/Helpers/DatabaseTestHelper.php
+++ b/tests/Helpers/DatabaseTestHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Helpers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+trait DatabaseTestHelper
+{
+    use RefreshDatabase;
+
+    /**
+     * テスト用のシードデータを実行
+     *
+     * @param string|array $seederClass
+     * @return void
+     */
+    protected function seedTestData($seederClass): void
+    {
+        if (is_array($seederClass)) {
+            foreach ($seederClass as $seeder) {
+                $this->seed($seeder);
+            }
+        } else {
+            $this->seed($seederClass);
+        }
+    }
+
+    /**
+     * トランザクション内でテストを実行
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    protected function withinTransaction(callable $callback)
+    {
+        return DB::transaction(function () use ($callback) {
+            return $callback();
+        });
+    }
+
+    /**
+     * データベースに特定のレコードが存在することを確認
+     *
+     * @param string $table
+     * @param array $data
+     * @param string|null $connection
+     * @return void
+     */
+    protected function assertDatabaseHasExact(string $table, array $data, ?string $connection = null): void
+    {
+        $count = DB::connection($connection)
+            ->table($table)
+            ->where($data)
+            ->count();
+
+        $this->assertEquals(1, $count, "Failed asserting that exactly one row in table [{$table}] matches the attributes.");
+    }
+
+    /**
+     * データベースにレコードが存在しないことを確認
+     *
+     * @param string $table
+     * @param string|null $connection
+     * @return void
+     */
+    protected function assertDatabaseIsEmpty(string $table, ?string $connection = null): void
+    {
+        $count = DB::connection($connection)
+            ->table($table)
+            ->count();
+
+        $this->assertEquals(0, $count, "Failed asserting that table [{$table}] is empty.");
+    }
+
+    /**
+     * データベースのレコード数を確認
+     *
+     * @param string $table
+     * @param int $expectedCount
+     * @param array $where
+     * @param string|null $connection
+     * @return void
+     */
+    protected function assertDatabaseRecordCount(string $table, int $expectedCount, array $where = [], ?string $connection = null): void
+    {
+        $query = DB::connection($connection)->table($table);
+        
+        if (!empty($where)) {
+            $query->where($where);
+        }
+        
+        $actual = $query->count();
+
+        $this->assertEquals($expectedCount, $actual, "Failed asserting that table [{$table}] contains {$expectedCount} records.");
+    }
+
+    /**
+     * ソフトデリートされたレコードが存在することを確認
+     *
+     * @param string $model
+     * @param array $data
+     * @return void
+     */
+    protected function assertSoftDeleted(string $model, array $data): void
+    {
+        $instance = new $model;
+        $table = $instance->getTable();
+        
+        $count = DB::table($table)
+            ->where($data)
+            ->whereNotNull('deleted_at')
+            ->count();
+
+        $this->assertGreaterThan(0, $count, "Failed asserting that a soft deleted row in table [{$table}] matches the attributes.");
+    }
+}


### PR DESCRIPTION
## Summary
- テスト環境の包括的な基盤構築を実施
- テストドキュメントとヘルパー関数を整備
- ファクトリーとシーダーでテストデータ準備を効率化

## 実装内容

### 1. ドキュメント整備
- **TESTING.md**: テスト戦略、ピラミッド、実行方法、ベストプラクティスを記載
- **CLAUDE.md**: プロジェクトルールにテストガイドラインを追加
- **README.md**: テスト実行コマンドを追記

### 2. テスト環境設定
- phpunit.xmlでインメモリSQLiteデータベースを設定
- テスト時の高速化とデータ独立性を確保

### 3. テストヘルパー作成
- **AuthTestHelper**: 認証関連のテストヘルパー
- **DatabaseTestHelper**: データベースアサーション拡張
- **ApiTestHelper**: APIテスト用ヘルパー

### 4. ファクトリー拡充
- **BookFactory**: 本のテストデータ生成（プログラミング本、小説、ビジネス書）
- **BookShelfFactory**: 本棚のテストデータ生成（公開/非公開、テーマ別）

### 5. テストシーダー
- **TestBookSeeder**: 統合テスト用の一貫したテストデータセット

### 6. バグ修正
- usersテーブルのマイグレーションで重複するprimary key定義を修正

## テスト結果
- 基本的なユニットテストが正常に動作することを確認
- 今後、各コントローラーのテストを追加予定

## 関連イシュー
Fixes #87

🤖 Generated with [Claude Code](https://claude.ai/code)